### PR TITLE
Upgrade wrapper from released tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ In order to use the `hugow` binary, you only need to download it and place it in
 of your Hugo project.
 
 ```bash
-curl -o hugow https://raw.githubusercontent.com/khos2ow/hugo-wrapper/master/hugow && chmod +x hugow
+curl -o hugow https://github.com/khos2ow/hugo-wrapper/releases/download/v1.0.2/hugow && chmod +x hugow
 ```
 
 or
 
 ```bash
-wget -O hugow https://raw.githubusercontent.com/khos2ow/hugo-wrapper/master/hugow && chmod +x hugow
+wget -O hugow https://github.com/khos2ow/hugo-wrapper/releases/download/v1.0.2/hugow && chmod +x hugow
 ```
 
 ## Upgrade Hugo Wrapper

--- a/example/hugow
+++ b/example/hugow
@@ -19,7 +19,7 @@
 # ------------------------------------------------------------------------------
 
 # ------------------------------------------------------------------------------
-# Hugo Wrapper (v1.0.1)
+# Hugo Wrapper (v1.0.2)
 #
 # Hugo Wrapper is a POSIX-style shell script which acts as a wrapper to download
 # and execute Hugo binary for your platform. It  can  be  executed in variety of
@@ -35,7 +35,7 @@
 
 set -e
 
-VERSION_NUMBER="v1.0.1"
+VERSION_NUMBER="v1.0.2"
 
 # hugo-wrapper command available flags
 get_version=""
@@ -281,7 +281,11 @@ fi
 # ------------------------------------------------------------------------------
 if [ "$upgrade" = true ]; then
     printf "downloading hugow binary ... "
-    $DOWNLOAD_COMMAND $DOWNLOAD_SILENT $DOWNLOAD_REDIRECT $DOWNLOAD_OUTPUT "hugow" "https://raw.githubusercontent.com/khos2ow/hugo-wrapper/master/hugow" &
+
+    latest_release=`$DOWNLOAD_COMMAND $DOWNLOAD_SILENT $DOWNLOAD_REDIRECT ${DOWNLOAD_OUTPUT}- https://api.github.com/repos/khos2ow/hugo-wrapper/releases/latest`
+    versionToDownload=`parse_json "$latest_release" "tag_name"`
+
+    $DOWNLOAD_COMMAND $DOWNLOAD_SILENT $DOWNLOAD_REDIRECT $DOWNLOAD_OUTPUT "hugow" "https://github.com/khos2ow/hugo-wrapper/releases/download/${versionToDownload}/hugow" &
     wait
     printf "[done]\n"
     chmod +x hugow

--- a/hugow
+++ b/hugow
@@ -19,7 +19,7 @@
 # ------------------------------------------------------------------------------
 
 # ------------------------------------------------------------------------------
-# Hugo Wrapper (v1.0.1)
+# Hugo Wrapper (v1.0.2)
 #
 # Hugo Wrapper is a POSIX-style shell script which acts as a wrapper to download
 # and execute Hugo binary for your platform. It  can  be  executed in variety of
@@ -35,7 +35,7 @@
 
 set -e
 
-VERSION_NUMBER="v1.0.1"
+VERSION_NUMBER="v1.0.2"
 
 # hugo-wrapper command available flags
 get_version=""
@@ -281,7 +281,11 @@ fi
 # ------------------------------------------------------------------------------
 if [ "$upgrade" = true ]; then
     printf "downloading hugow binary ... "
-    $DOWNLOAD_COMMAND $DOWNLOAD_SILENT $DOWNLOAD_REDIRECT $DOWNLOAD_OUTPUT "hugow" "https://raw.githubusercontent.com/khos2ow/hugo-wrapper/master/hugow" &
+
+    latest_release=`$DOWNLOAD_COMMAND $DOWNLOAD_SILENT $DOWNLOAD_REDIRECT ${DOWNLOAD_OUTPUT}- https://api.github.com/repos/khos2ow/hugo-wrapper/releases/latest`
+    versionToDownload=`parse_json "$latest_release" "tag_name"`
+
+    $DOWNLOAD_COMMAND $DOWNLOAD_SILENT $DOWNLOAD_REDIRECT $DOWNLOAD_OUTPUT "hugow" "https://github.com/khos2ow/hugo-wrapper/releases/download/${versionToDownload}/hugow" &
     wait
     printf "[done]\n"
     chmod +x hugow


### PR DESCRIPTION
Upgrade the `hugow` binary from the latest [releases](https://github.com/khos2ow/hugo-wrapper/releases).