### PR TITLE
Fix error when downloading the latest extended version

### DIFF
--- a/hugow
+++ b/hugow
@@ -250,7 +250,7 @@ download_version() {
         versionDownloadSuffix=""
 
         if [ "$isExtended" = true ]; then
-            if [ "$majorVersion" -eq 0 ] && [ "$minorVersion" -lt 56 ]; then
+            if [ "$versionToDownload" != "LATEST" ] && [ "$majorVersion" -eq 0 ] && [ "$minorVersion" -lt 56 ]; then
                 checksumFilenamePrefix="hugo_extended"
             fi
 


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.

### Description

This fixes a bug, where an error occurs when trying to download the LATEST version of hugo extended.

### Checklist

Put an `x` into all boxes that apply:

#### Checks

- [x] All checks pass when I run `make check`.

(Except two, which were there before)

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
