### PR TITLE
Execute sha256sum with alpine compatible argument

### DIFF
--- a/hugow
+++ b/hugow
@@ -221,7 +221,7 @@ parse_json() {
 perform_checksum() {
     if [ -n "$1" ]; then
         if command -v sha256sum >/dev/null; then
-            echo "$1" | sha256sum --check >/dev/null
+            echo "$1" | sha256sum -c >/dev/null
         elif command -v shasum >/dev/null; then
             echo "$1" | shasum --algorithm 256 --check >/dev/null
         elif command -v cksum >/dev/null; then


### PR DESCRIPTION
### Prerequisites

- [x] This pull request fixes a bug.

### Description

This pull request enables hugow to run on alpine. Alpines sha256sum doesn't offer the `--check` option but only the short equivalent `-c`.

#### Checks

- [x] All checks pass when I run `make check`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
