### PR TITLE
Handle new version string format for extended hugo since 0.81.0

### DIFF
--- a/hugow
+++ b/hugow
@@ -349,7 +349,7 @@ fi
 # download hugo binary and save it as ${BASE_DIR}/.hugo/hugo
 # ------------------------------------------------------------------------------
 if [ -r "$BASE_DIR/.hugo/hugo" ]; then
-    current_binary_version=$("$BASE_DIR/.hugo/hugo" version | sed -ne 's/[^0-9]*\(\([0-9]*\.\)\{0,4\}[0-9]*\(-[0-9a-fA-F]*\)*\(\/extended\)*\).*/\1/p' | sed 's/-[0-9A-Fa-f]*//p' | sed 's/^ *//;s/ *$//' | uniq)
+    current_binary_version=$("$BASE_DIR/.hugo/hugo" version | sed -ne 's/[^0-9]*\(\([0-9]*\.\)\{0,4\}[0-9]*\(-[0-9a-fA-F]*\)*\([/+]extended\)*\).*/\1/p' | sed 's/-[0-9A-Fa-f]*//p' | sed 's/^ *//;s/ *$//' | sed 's/+extended/\/extended/' | uniq)
 
     if [ "$get_extended" = true ]; then
         suffix_extended_version="/extended"


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

### Description

Since [e8df097745](https://github.com/gohugoio/hugo/commit/e8df09774534abe6131eb455b4f5c614fb438983), the extended hugo prints a suffix as `+extended` instead of `/extended`. One of the easiest solutions seems to be to accept both formats and convert a version into the former one. Without this change, the wrapper compares versions improperly and always downloads a binary.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

#### Checks

- [x] All checks pass when I run `make check`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
