### PR TITLE
Fix downloading hugo for macOS after hugo version 0.102.0

### DIFF
--- a/hugow
+++ b/hugow
@@ -260,6 +260,14 @@ download_version() {
             versionDownloadSuffix="/extended"
         fi
 
+        if [ "$os_type" = "macOS" ]; then
+            if [ "$versionToDownload" = "LATEST" ]; then
+                os_arch="universal"
+            elif [ "$majorVersion" -ge 0 ] && [ "$minorVersion" -ge 102 ]; then
+                os_arch="universal"
+            fi
+        fi
+
         if [ "$versionToDownload" = "LATEST" ]; then
             latest_release=$($DOWNLOAD_COMMAND $DOWNLOAD_SILENT $DOWNLOAD_REDIRECT ${DOWNLOAD_OUTPUT}- https://api.github.com/repos/gohugoio/hugo/releases/latest)
             versionToDownload=$(parse_json "$latest_release" "tag_name")


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

### Description

In hugo 0.102.0, the macos binaries are distributed in a combined archive for both arm64 and x64 (See notes here: https://github.com/gohugoio/hugo/releases/tag/v0.102.0). This breaks downloading hugo from this version on with hugo-wrapper.

### Issues Resolved

### Checklist

Put an `x` into all boxes that apply:

#### Checks

- [x] All checks pass when I run `make check`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
