### PR TITLE
Support universal binaries on macOS

### DIFF
--- a/hugow
+++ b/hugow
@@ -132,7 +132,7 @@ fi
 os_type=""
 
 case "$(uname -s)" in
-Darwin) os_type="macOS" ;;
+Darwin) os_type="Darwin" ;;
 Linux) os_type="Linux" ;;
 DragonFly) os_type="DragonFlyBSD" ;;
 FreeBSD) os_type="FreeBSD" ;;
@@ -146,14 +146,18 @@ esac
 # OS architecture
 os_arch=""
 
-case "$(uname -m)" in
-x86) os_arch="32bit" ;;
-x86_64) os_arch="64bit" ;;
-amd64) os_arch="64bit" ;;
-armv7l) os_arch="ARM" ;;
-armv8) os_arch="ARM64" ;;
-arm64) os_arch="ARM64" ;;
-esac
+if [ "$os_type" = "Darwin" ]; then
+    os_arch="Universal"
+else
+    case "$(uname -m)" in
+    x86) os_arch="32bit" ;;
+    x86_64) os_arch="64bit" ;;
+    amd64) os_arch="64bit" ;;
+    armv7l) os_arch="ARM" ;;
+    armv8) os_arch="ARM64" ;;
+    arm64) os_arch="ARM64" ;;
+    esac
+fi
 
 if [ -z "$os_type" ] || [ -z "$os_arch" ]; then
     echo "Error: Unknown OS type or architecture"


### PR DESCRIPTION
Since v0.102.0, hugo ships universal binaries for macOS. And since v0.103.0, it refers to macOS as Darwin.

### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [x] This pull request introduces breaking change.

### Description

Describe what this pull request achieves.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

#### Checks

- [ ] All checks pass when I run `make check`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
